### PR TITLE
Add GW2 map name and wiki integration

### DIFF
--- a/KXMapStudio.App/App.xaml.cs
+++ b/KXMapStudio.App/App.xaml.cs
@@ -56,6 +56,7 @@ namespace KXMapStudio.App
                     services.AddSingleton<PackLoader>();
                     services.AddSingleton<PackLoaderFactory>();
                     services.AddSingleton<WorkspaceManager>();
+                    services.AddSingleton<MapDataService>();
 
                     services.AddSingleton<IMarkerCrudService, MarkerCrudService>();
 
@@ -77,6 +78,9 @@ namespace KXMapStudio.App
         {
             Log.Information("Application starting up.");
             await AppHost!.StartAsync();
+
+            var mapDataService = AppHost.Services.GetRequiredService<MapDataService>();
+            _ = mapDataService.InitializeAsync();
 
             var mumbleService = AppHost.Services.GetRequiredService<MumbleService>();
             mumbleService.Start();

--- a/KXMapStudio.App/Converters/MapIdToNameConverter.cs
+++ b/KXMapStudio.App/Converters/MapIdToNameConverter.cs
@@ -1,0 +1,29 @@
+﻿using System.Globalization;
+using System.Windows.Data;
+
+using KXMapStudio.App.Services;
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace KXMapStudio.App.Converters;
+
+public class MapIdToNameConverter : IValueConverter
+{
+    // Lazy-load the service to avoid issues with design-time environments.
+    private readonly Lazy<MapDataService> _mapDataService = new(() =>
+        App.AppHost!.Services.GetRequiredService<MapDataService>());
+
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is int mapId)
+        {
+            return _mapDataService.Value.GetMapName(mapId);
+        }
+        return "Invalid ID";
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/KXMapStudio.App/Services/MapDataService.cs
+++ b/KXMapStudio.App/Services/MapDataService.cs
@@ -1,0 +1,125 @@
+﻿using System.IO;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using Microsoft.Extensions.Logging;
+
+namespace KXMapStudio.App.Services;
+
+public record MapNameEntry(
+    [property: JsonPropertyName("id")] string Id,
+    [property: JsonPropertyName("name")] string Name
+);
+
+public class MapDataService
+{
+    private readonly ILogger<MapDataService> _logger;
+    private readonly HttpClient _httpClient;
+    private Dictionary<int, string> _mapNames = new();
+
+    private const string ApiUrl = "https://api.guildwars2.com/v1/map_names.json";
+    private readonly string _cacheFilePath;
+
+    // Event to notify the UI when data is ready
+    public event Action? MapDataRefreshed;
+
+    public MapDataService(ILogger<MapDataService> logger)
+    {
+        _logger = logger;
+        _httpClient = new HttpClient();
+
+        // Define a safe, user-specific location for the cache file
+        var appDataPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        _cacheFilePath = Path.Combine(appDataPath, "KXMapStudio", "map_names.json");
+        Directory.CreateDirectory(Path.GetDirectoryName(_cacheFilePath)!);
+    }
+
+    // This is the main method to be called at app startup
+    public async Task InitializeAsync()
+    {
+        // Load from cache first for a fast startup. This is non-blocking.
+        await LoadFromCacheAsync();
+
+        // Then, try to refresh from the API in the background.
+        // This won't block the UI and will update the data if successful.
+        await FetchAndCacheAsync();
+    }
+
+    private async Task FetchAndCacheAsync()
+    {
+        _logger.LogInformation("Fetching latest map names from API.");
+        try
+        {
+            var mapEntries = await _httpClient.GetFromJsonAsync<List<MapNameEntry>>(ApiUrl);
+            if (mapEntries == null)
+            {
+                _logger.LogWarning("API returned null for map names.");
+                return;
+            }
+
+            var newMapNames = mapEntries
+                .Where(e => int.TryParse(e.Id, out _))
+                .ToDictionary(e => int.Parse(e.Id), e => e.Name);
+
+            // If we got new data, update in-memory dict, save to cache, and notify listeners.
+            _mapNames = newMapNames;
+            await SaveToCacheAsync();
+            _logger.LogInformation("Successfully refreshed and cached {Count} map names.", _mapNames.Count);
+            MapDataRefreshed?.Invoke();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to fetch map names from API. Will rely on cached data if available.");
+        }
+    }
+
+    private async Task LoadFromCacheAsync()
+    {
+        if (!File.Exists(_cacheFilePath)) return;
+
+        try
+        {
+            _logger.LogInformation("Loading map names from local cache: {Path}", _cacheFilePath);
+            var json = await File.ReadAllTextAsync(_cacheFilePath);
+            var cachedNames = JsonSerializer.Deserialize<Dictionary<int, string>>(json);
+            if (cachedNames != null)
+            {
+                _mapNames = cachedNames;
+                MapDataRefreshed?.Invoke(); // Notify UI that some data is ready
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load map names from cache file.");
+        }
+    }
+
+    private async Task SaveToCacheAsync()
+    {
+        try
+        {
+            var json = JsonSerializer.Serialize(_mapNames);
+            await File.WriteAllTextAsync(_cacheFilePath, json);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to save map names to cache.");
+        }
+    }
+
+    public string GetMapName(int mapId)
+    {
+        return _mapNames.TryGetValue(mapId, out var name) ? name : "Unknown Map";
+    }
+
+    public string GetWikiUrl(string mapName)
+    {
+        if (string.IsNullOrEmpty(mapName) || mapName == "Unknown Map")
+        {
+            return string.Empty;
+        }
+        return $"https://wiki.guildwars2.com/wiki/{Uri.EscapeDataString(mapName.Replace(' ', '_'))}";
+    }
+}

--- a/KXMapStudio.App/ViewModels/MainViewModel.Events.cs
+++ b/KXMapStudio.App/ViewModels/MainViewModel.Events.cs
@@ -15,6 +15,7 @@ public partial class MainViewModel
         PackState.SelectedMarkers.CollectionChanged += OnSelectedMarkersChanged;
         _historyService.PropertyChanged += OnHistoryChanged;
         MumbleService.PropertyChanged += OnMumbleServiceChanged;
+        _mapDataService.MapDataRefreshed += OnMapDataRefreshed;
     }
 
     private void OnPackStateChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
@@ -64,6 +65,32 @@ public partial class MainViewModel
         if (e.PropertyName == nameof(MumbleService.IsAvailable))
         {
             AddMarkerFromGameCommand.NotifyCanExecuteChanged();
+        }
+        if (e.PropertyName == nameof(MumbleService.CurrentMapId) || e.PropertyName == nameof(MumbleService.IsAvailable))
+        {
+            if (MumbleService.IsAvailable)
+            {
+                LiveMapName = _mapDataService.GetMapName((int)MumbleService.CurrentMapId);
+            }
+            else
+            {
+                LiveMapName = "N/A";
+            }
+        }
+    }
+
+    private void OnMapDataRefreshed()
+    {
+        // Force a refresh of the live map name when data arrives
+        OnMumbleServiceChanged(this, new(nameof(MumbleService.CurrentMapId)));
+
+        // Force the grid to re-evaluate the converter bindings
+        // A simple way is to "reset" the collection which makes the UI redraw
+        var markers = MarkersInView.ToList();
+        MarkersInView.Clear();
+        foreach (var marker in markers)
+        {
+            MarkersInView.Add(marker);
         }
     }
 

--- a/KXMapStudio.App/ViewModels/MainViewModel.cs
+++ b/KXMapStudio.App/ViewModels/MainViewModel.cs
@@ -1,4 +1,4 @@
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 using System.IO;
 using System.Reflection;
 
@@ -67,12 +67,16 @@ public partial class MainViewModel : ObservableObject
     private readonly HistoryService _historyService;
     private readonly GlobalHotkeyService _globalHotkeyService;
     private readonly UpdateService _updateService;
+    private readonly MapDataService _mapDataService;
 
     [ObservableProperty]
     private bool _isUpdateAvailable;
 
     [ObservableProperty]
     private GitHubRelease? _latestRelease;
+
+    [ObservableProperty]
+    private string _liveMapName = "Loading...";
 
     public MainViewModel(
         IPackStateService packStateService,
@@ -81,7 +85,8 @@ public partial class MainViewModel : ObservableObject
         IFeedbackService feedbackService,
         HistoryService historyService,
         GlobalHotkeyService globalHotkeyService,
-        UpdateService updateService)
+        UpdateService updateService,
+        MapDataService mapDataService)
     {
         PackState = packStateService;
         MumbleService = mumbleService;
@@ -90,6 +95,7 @@ public partial class MainViewModel : ObservableObject
         _historyService = historyService;
         _globalHotkeyService = globalHotkeyService;
         _updateService = updateService;
+        _mapDataService = mapDataService;
 
         AppVersion = $"Version {Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? "Unknown"}";
 

--- a/KXMapStudio.App/Views/LiveDataView.xaml
+++ b/KXMapStudio.App/Views/LiveDataView.xaml
@@ -49,8 +49,13 @@
                 <TextBlock Grid.Row="1" Grid.Column="0" Text="Character:" Style="{StaticResource LabelStyle}"/>
                 <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding MumbleService.CharacterName, Mode=OneWay}" Style="{StaticResource ValueStyle}"/>
 
-                <TextBlock Grid.Row="2" Grid.Column="0" Text="Map ID:" Style="{StaticResource LabelStyle}"/>
-                <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding MumbleService.CurrentMapId, Mode=OneWay}" Style="{StaticResource ValueStyle}"/>
+                <TextBlock Grid.Row="2" Grid.Column="0" Text="Map:" Style="{StaticResource LabelStyle}" VerticalAlignment="Top" Margin="0,2,10,2"/>
+                <StackPanel Grid.Row="2" Grid.Column="1" Orientation="Vertical">
+                    <TextBlock Text="{Binding MumbleService.CurrentMapId, Mode=OneWay}" Style="{StaticResource ValueStyle}" FontWeight="Bold"/>
+                    <TextBlock Text="{Binding LiveMapName, Mode=OneWay}" Style="{StaticResource ValueStyle}"
+                               Foreground="{DynamicResource MaterialDesign.Brush.ForegroundLight}"
+                               TextWrapping="Wrap"/>
+                </StackPanel>
 
                 <TextBlock Grid.Row="4" Grid.Column="0" Text="Player X:" Style="{StaticResource LabelStyle}"/>
                 <TextBlock Grid.Row="4" Grid.Column="1" Text="{Binding MumbleService.PlayerPosition.X, Mode=OneWay, StringFormat=F2}" Style="{StaticResource ValueStyle}"/>

--- a/KXMapStudio.App/Views/MainView.xaml
+++ b/KXMapStudio.App/Views/MainView.xaml
@@ -27,6 +27,7 @@
 
     <Window.Resources>
         <ResourceDictionary>
+            <converters:MapIdToNameConverter x:Key="MapIdToNameConverter" />
             <converters:BooleanToVisibilityInverterConverter x:Key="BooleanToVisibilityInverterConverter" />
             <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
         </ResourceDictionary>
@@ -212,6 +213,7 @@
                             </i:Interaction.Behaviors>
                             <DataGrid.Columns>
                                 <DataGridTextColumn Header="Map ID" Binding="{Binding MapId, Mode=TwoWay}" Width="SizeToCells" MinWidth="80" EditingElementStyle="{StaticResource MaterialDesignDataGridTextColumnEditingStyle}" />
+                                <DataGridTextColumn Header="Map Name" Binding="{Binding MapId, Converter={StaticResource MapIdToNameConverter}, Mode=OneWay}" IsReadOnly="True" Width="SizeToHeader" MinWidth="120" />
                                 <DataGridTextColumn Header="X" Binding="{Binding X, StringFormat=F3, Mode=TwoWay}" Width="SizeToCells" MinWidth="80" EditingElementStyle="{StaticResource MaterialDesignDataGridTextColumnEditingStyle}" />
                                 <DataGridTextColumn Header="Y" Binding="{Binding Y, StringFormat=F3, Mode=TwoWay}" Width="SizeToCells" MinWidth="80" EditingElementStyle="{StaticResource MaterialDesignDataGridTextColumnEditingStyle}" />
                                 <DataGridTextColumn Header="Z" Binding="{Binding Z, StringFormat=F3, Mode=TwoWay}" Width="SizeToCells" MinWidth="80" EditingElementStyle="{StaticResource MaterialDesignDataGridTextColumnEditingStyle}" />

--- a/KXMapStudio.App/Views/PropertyEditorView.xaml
+++ b/KXMapStudio.App/Views/PropertyEditorView.xaml
@@ -13,10 +13,22 @@
                        Style="{StaticResource MaterialDesignSubtitle1TextBlock}" 
                        Margin="8,8,8,16"/>
 
-            <TextBox Style="{StaticResource MaterialDesignFloatingHintTextBox}"
-                     materialDesign:HintAssist.Hint="Map ID"
-                     Text="{Binding MapId, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
-                     Margin="8,0,8,12"/>
+            <Grid Margin="8,0,8,12">
+                <TextBox Style="{StaticResource MaterialDesignFloatingHintTextBox}"
+                         materialDesign:HintAssist.Hint="Map ID"
+                         materialDesign:HintAssist.HelperText="{Binding MapName}"
+                         Text="{Binding MapId, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
+                         Padding="0 0 32 0" />
+
+                <Button Style="{StaticResource MaterialDesignIconButton}"
+                        Command="{Binding OpenMapWikiCommand}"
+                        ToolTip="View map on the Guild Wars 2 Wiki"
+                        HorizontalAlignment="Right"
+                        VerticalAlignment="Bottom"
+                        Margin="0,0,4,8">
+                    <materialDesign:PackIcon Kind="BookOpenPageVariantOutline" />
+                </Button>
+            </Grid>
 
             <TextBox Style="{StaticResource MaterialDesignFloatingHintTextBox}"
                      materialDesign:HintAssist.Hint="X Coordinate"


### PR DESCRIPTION
Introduces comprehensive map name integration and navigation across the application.

- **New MapDataService:** Fetches and caches Guild Wars 2 map names from the API, providing resilience during game updates by utilizing cached data.
- **Property Editor Improvements:**
    - Displays map name next to Map ID in the Property Editor for selected markers.
    - Adds a clickable icon to directly open the GW2 Wiki page for the associated map.
    - Corrected vertical alignment of the map ID input field and wiki button.
- **Live Game Data Panel:**
    - Shows the map name alongside the Map ID for the current player's location.
    - Redesigned layout to ensure long map names are fully visible and do not get clipped.
- **Marker Data Grid:**
    - Added a new read-only column to display the map name directly in the main marker list for quick reference.

These changes significantly improve the usability and contextual information available to users when working with markers.